### PR TITLE
add dhcp-option=6 to no longer advertise bbbvpn server as a nameserver

### DIFF
--- a/templates/dnsmasq.conf.erb
+++ b/templates/dnsmasq.conf.erb
@@ -14,5 +14,6 @@ resolv-file=/etc/resolv.conf.freifunk
 addn-hosts=/tmp/hosts-olsr
 dhcp-range=<%= @dhcp_range %>
 dhcp-option=3
+dhcp-option=6
 dhcp-lease-max=<%= @dhcp_lease_max %>
 


### PR DESCRIPTION
The clients were automatically setting the bbbvpn server a nameserver.  Adding dhcp-option=6 disables this.

Fixes https://github.com/freifunk-berlin/firmware/issues/742